### PR TITLE
Append `hf` for "hard-float" in "llvm-target"

### DIFF
--- a/armv7-vita-eabihf.json
+++ b/armv7-vita-eabihf.json
@@ -20,7 +20,7 @@
   "linker": "arm-vita-eabi-ld",
   "linker-flavor": "ld",
   "linker-is-gnu": true,
-  "llvm-target": "armv7a-vita-eabi",
+  "llvm-target": "armv7a-vita-eabihf",
   "max-atomic-width": 32,
   "no-compiler-rt": true,
   "os": "vita",
@@ -30,5 +30,5 @@
   "target-c-int-width": "32",
   "target-endian": "little",
   "target-pointer-width": "32",
-  "vendor":"sony",
+  "vendor": "sony"
 }


### PR DESCRIPTION
I got `uses VFP register arguments` when I tried to build `hello_rust_world` example from `psp2-sys`. Changing "llvm-target" from "armv7a-vita-eabi" to "armv7a-vita-eabihf" fixed it. It was not the only issue i got but i want to fix em all.

Right now I would like to communicate with the author. Also it was super cool to see this demo running! 